### PR TITLE
remove trailing delimiter and double delimiter on namespace debug

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,15 @@
 {
+    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+    "C_Cpp.default.compilerPath": "/usr/bin/g++-13",
+    "C_Cpp.intelliSenseEngine": "Tag Parser",
+    "C_Cpp.clang_format_style": "{ BasedOnStyle: Google, BreakBeforeBraces: Attach }",
+    
+
     "cmake.configureOnOpen": false,
     "cmake.configureOnEdit": false,
     "cmake.automaticReconfigure": false,
     "cmake.buildBeforeRun": false,
     "cmake.buildTask": false,
-    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
-    "C_Cpp.default.compilerPath": "/usr/bin/g++-13",
-    "C_Cpp.intelliSenseEngine": "Tag Parser",
     "cmake.deleteBuildDirOnCleanConfigure": false,
     "testMate.cpp.test.executables": "{build,Build,BUILD,out,Out,OUT,moxygen}/**/*{test,Test,TEST}*"
 }

--- a/moxygen/MoQFramer.h
+++ b/moxygen/MoQFramer.h
@@ -341,12 +341,19 @@ struct TrackNamespace {
           tn.trackNamespace.begin(), tn.trackNamespace.end());
     }
   };
-  friend std::ostream& operator<<(
-      std::ostream& os,
-      const TrackNamespace& trackNs) {
-    for (const auto& s : trackNs.trackNamespace) {
-      os << s << "/";
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const TrackNamespace& trackNs) {
+    if (trackNs.trackNamespace.empty()) {
+      return os;
     }
+
+    // Iterate through all elements except the last one
+    for (size_t i = 0; i < trackNs.trackNamespace.size() - 1; ++i) {
+      os << trackNs.trackNamespace[i] << '/';
+    }
+
+    // Add the last element without a trailing slash
+    os << trackNs.trackNamespace.back();
     return os;
   }
   bool empty() const {
@@ -386,6 +393,12 @@ struct FullTrackName {
   bool operator<(const FullTrackName& other) const {
     return trackNamespace < other.trackNamespace ||
         (trackNamespace == other.trackNamespace && trackName < other.trackName);
+  }
+  friend std::ostream& operator<<(std::ostream& os, const FullTrackName& ftn) {
+    if (ftn.trackNamespace.empty()) {
+      return os << ftn.trackName;
+    }
+    return os << ftn.trackNamespace << '/' << ftn.trackName;
   }
   struct hash {
     size_t operator()(const FullTrackName& ftn) const {

--- a/moxygen/MoQSession.cpp
+++ b/moxygen/MoQSession.cpp
@@ -436,7 +436,7 @@ void MoQSession::onFetchError(FetchError fetchError) {
 }
 
 void MoQSession::onAnnounce(Announce ann) {
-  XLOG(DBG1) << __func__ << " sess=" << this;
+  XLOG(DBG1) << __func__ << " sess=" << this << " ns=" << ann.trackNamespace;
   controlMessages_.enqueue(std::move(ann));
 }
 

--- a/moxygen/relay/MoQRelay.cpp
+++ b/moxygen/relay/MoQRelay.cpp
@@ -218,8 +218,7 @@ folly::coro::Task<void> MoQRelay::forwardTrack(
     std::shared_ptr<MoQForwarder> fowarder) {
   while (auto obj = co_await track->objects().next()) {
     XLOG(DBG1) << __func__
-               << " new object t=" << obj.value()->fullTrackName.trackNamespace
-               << obj.value()->fullTrackName.trackName
+               << " new object t=" << obj.value()->fullTrackName
                << " g=" << obj.value()->header.group
                << " o=" << obj.value()->header.id;
     folly::IOBufQueue payloadBuf{folly::IOBufQueue::cacheChainLength()};
@@ -262,8 +261,7 @@ void MoQRelay::onUnsubscribe(
     subscription.forwarder->removeSession(session, unsub.subscribeID);
     if (subscription.forwarder->empty()) {
       XLOG(INFO) << "Removed last subscriber for "
-                 << subscriptionIt->first.trackNamespace
-                 << subscriptionIt->first.trackName;
+                 << subscriptionIt->first.trackNamespace;
       subscription.cancellationSource.requestCancellation();
       subscription.upstream->unsubscribe({subscription.subscribeID});
       subscriptionIt = subscriptions_.erase(subscriptionIt);
@@ -324,8 +322,7 @@ void MoQRelay::removeSession(const std::shared_ptr<MoQSession>& session) {
     }
     if (subscription.forwarder->empty()) {
       XLOG(INFO) << "Removed last subscriber for "
-                 << subscriptionIt->first.trackNamespace
-                 << subscriptionIt->first.trackName;
+                 << subscriptionIt->first;
       subscription.upstream->unsubscribe({subscription.subscribeID});
       subscriptionIt = subscriptions_.erase(subscriptionIt);
     } else {

--- a/moxygen/relay/MoQRelay.cpp
+++ b/moxygen/relay/MoQRelay.cpp
@@ -260,8 +260,7 @@ void MoQRelay::onUnsubscribe(
     auto& subscription = subscriptionIt->second;
     subscription.forwarder->removeSession(session, unsub.subscribeID);
     if (subscription.forwarder->empty()) {
-      XLOG(INFO) << "Removed last subscriber for "
-                 << subscriptionIt->first.trackNamespace;
+      XLOG(INFO) << "Removed last subscriber for " << subscriptionIt->first;
       subscription.cancellationSource.requestCancellation();
       subscription.upstream->unsubscribe({subscription.subscribeID});
       subscriptionIt = subscriptions_.erase(subscriptionIt);

--- a/moxygen/relay/MoQRelayServer.cpp
+++ b/moxygen/relay/MoQRelayServer.cpp
@@ -58,7 +58,7 @@ class MoQRelayServer : MoQServer {
 
     void operator()(SubscribeRequest subscribeReq) const override {
       XLOG(INFO) << "SubscribeRequest track="
-                 << subscribeReq.fullTrackName.trackNamespace << "/"
+                 << subscribeReq.fullTrackName.trackNamespace << '/'
                  << subscribeReq.fullTrackName.trackName;
       server_.relay_.onSubscribe(std::move(subscribeReq), clientSession_)
           .scheduleOn(clientSession_->getEventBase())

--- a/moxygen/relay/MoQRelayServer.cpp
+++ b/moxygen/relay/MoQRelayServer.cpp
@@ -57,9 +57,7 @@ class MoQRelayServer : MoQServer {
     }
 
     void operator()(SubscribeRequest subscribeReq) const override {
-      XLOG(INFO) << "SubscribeRequest track="
-                 << subscribeReq.fullTrackName.trackNamespace << '/'
-                 << subscribeReq.fullTrackName.trackName;
+      XLOG(INFO) << "SubscribeRequest track=" << subscribeReq.fullTrackName;
       server_.relay_.onSubscribe(std::move(subscribeReq), clientSession_)
           .scheduleOn(clientSession_->getEventBase())
           .start();


### PR DESCRIPTION
namespace debug output often showed a trailing delimiter and
full trackname debug output sometimes showed a double delimiter

add FullTrackName ostream operator

also made VS Code conform to one-true-brace formatting